### PR TITLE
Prevent non-addon files from being installed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
As an end-user, it's annoying for the very first experience I have with a plugin being preventing it from spraying a bunch of stuff I don't want into my project directory.

<details>
<summary>Current Installation Screenshot</summary>

![Godot_v3 5 1-stable_win64_taXwWk9OeL](https://user-images.githubusercontent.com/18042232/219366024-14e22f64-4a2c-4a93-907d-b72fa83ec903.png)

</details>

These fields in .gitattribute will tell the assetlib not to export these files in the first place.

If you also want your example to be available in the assetlib, you can add:

```
/example    !export-ignore
/example/** !export-ignore
```