### PR TITLE
Fix 19

### DIFF
--- a/addons/resources_spreadsheet_view/editor_view.gd
+++ b/addons/resources_spreadsheet_view/editor_view.gd
@@ -95,12 +95,7 @@ func display_folder(folderpath : String, sort_by : String = "", sort_reverse : b
 	current_path = folderpath
 	node_columns.update()
 
-	await get_tree().create_timer(0.25).timeout
-	if node_table_root.get_child_count() == 0:
-		display_folder(folderpath, sort_by, sort_reverse, force_rebuild)
-
-	else:
-		emit_signal("grid_updated")
+	emit_signal("grid_updated")
 
 
 func refresh(force_rebuild : bool = true):

--- a/addons/resources_spreadsheet_view/main_screen/table_pages.gd
+++ b/addons/resources_spreadsheet_view/main_screen/table_pages.gd
@@ -98,6 +98,7 @@ func _on_button_pressed(button):
 
 func _on_LineEdit_value_changed(value):
 	rows_per_page = value
+	current_page = 0
 	_update_view()
 
 

--- a/addons/resources_spreadsheet_view/main_screen/table_pages.gd
+++ b/addons/resources_spreadsheet_view/main_screen/table_pages.gd
@@ -39,6 +39,8 @@ func _on_grid_updated():
 	var sort_type = node_editor_view_root.column_types[node_editor_view_root.columns.find(sort_property)]
 	var property_values = []
 	property_values.resize(page_count)
+	if(node_editor_view_root.rows.size() == 0):
+		return
 	for i in page_count:
 		property_values[i] = node_editor_view_root.rows[i * rows_per_page].get(sort_property)
 


### PR DESCRIPTION
Fixes #19 , though there's no user-friendly solution for an empty directory and the interface is just left empty.  Also has knock on effect that the page is reset to the first one every time the user changes the rows_per_page.

(Apologies if squashed commits would be better, but github's web editing doesn't seem to allow it yet.  If it's vital I might eventually get around to a local clone and proper git client, but it might have to wait quite a while.  Feel free to squash them yourself if you want though!)