### PR TITLE
Fix intermittent crash due to deleted objects

### DIFF
--- a/addons/resources_spreadsheet_view/main_screen/column_header_manager.gd
+++ b/addons/resources_spreadsheet_view/main_screen/column_header_manager.gd
@@ -86,6 +86,10 @@ func _update_column_sizes():
 	show()
 	await get_tree().process_frame
 
+	# Abort if the node has been deleted since.
+	if !is_instance_valid(column_headers[0]):
+		return
+
 	get_parent().custom_minimum_size.y = column_headers[0].size.y
 	for i in column_headers.size():
 		column_headers[i].position.x = grid.get_child(i).position.x

--- a/addons/resources_spreadsheet_view/typed_cells/cell_editor_resource.gd
+++ b/addons/resources_spreadsheet_view/typed_cells/cell_editor_resource.gd
@@ -47,5 +47,7 @@ func is_text():
 
 
 func _on_preview_loaded(path : String, preview : Texture, thumbnail_preview : Texture, node):
-	node.get_node("Box/Tex").visible = true
-	node.get_node("Box/Tex").texture = preview
+	# Abort if the node has been deleted since.
+	if is_instance_valid(node):
+		node.get_node("Box/Tex").visible = true
+		node.get_node("Box/Tex").texture = preview


### PR DESCRIPTION
In callbacks and after await, gracefully handle the case where nodes have been deleted since. This seems to happen sometimes at startup of the editor.