### PR TITLE
Remove unnecessary instantiation in _on_search_cond_text_submitted

### DIFF
--- a/addons/resources_spreadsheet_view/editor_view.gd
+++ b/addons/resources_spreadsheet_view/editor_view.gd
@@ -391,8 +391,7 @@ func _on_search_cond_text_submitted(new_text : String):
 	new_script.source_code = "static func can_show(res, index):\n\treturn " + new_text
 	new_script.reload()
 
-	var new_script_instance = new_script.new()
-	search_cond = new_script_instance
+	search_cond = new_script
 	refresh()
 
 


### PR DESCRIPTION
As a static method is used it's not necessary to make an instance of the script.

Just something i noticed. Doesn't affect functionality.