### PR TITLE
Reverse checked items in Hide/Show panel

### DIFF
--- a/addons/resources_spreadsheet_view/main_screen/column_header_manager.gd
+++ b/addons/resources_spreadsheet_view/main_screen/column_header_manager.gd
@@ -132,7 +132,7 @@ func _on_visible_cols_about_to_popup():
 	
 	for i in columns.size():
 		popup.add_check_item(columns[i].capitalize(), i)
-		popup.set_item_checked(i, hidden_columns[current_path].has(columns[i]))
+		popup.set_item_checked(i, not hidden_columns[current_path].has(columns[i]))
 
 
 func _on_visible_cols_id_pressed(id : int):
@@ -140,11 +140,11 @@ func _on_visible_cols_id_pressed(id : int):
 	var popup = hide_columns_button.get_popup()
 	if popup.is_item_checked(id):
 		popup.set_item_checked(id, false)
-		hidden_columns[current_path].erase(columns[id])
+		hidden_columns[current_path][columns[id]] = true
 
 	else:
 		popup.set_item_checked(id, true)
-		hidden_columns[current_path][columns[id]] = true
+		hidden_columns[current_path].erase(columns[id])
 
 	editor_view.save_data()
 	update()


### PR DESCRIPTION
In my opinion it makes a whole lot more sense.
![image](https://github.com/don-tnowe/godot-resources-as-sheets-plugin/assets/66727710/444e3183-b60f-45dd-a886-cdc6558ed33c)

Any checked property is **enabled**, and should be seen in the spreadsheet, not the other way around.
The `saved_state.json` is entirely not affected by this change, as it's only visual.