### PR TITLE
remove usage of res://icon.png from typed_editors/dock_texture.tscn

### DIFF
--- a/addons/resources_spreadsheet_view/typed_editors/dock_texture.tscn
+++ b/addons/resources_spreadsheet_view/typed_editors/dock_texture.tscn
@@ -1,7 +1,8 @@
 [gd_scene load_steps=3 format=3 uid="uid://rww3gpl052bn"]
 
 [ext_resource type="Script" path="res://addons/resources_spreadsheet_view/typed_editors/dock_texture.gd" id="1"]
-[ext_resource type="Texture2D" uid="uid://c08qavfwqr3k7" path="res://icon.png" id="2_xbp0j"]
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_h3mns"]
 
 [node name="EditTexture" type="VBoxContainer"]
 anchors_preset = -1
@@ -54,7 +55,7 @@ mouse_filter = 2
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-texture = ExtResource("2_xbp0j")
+texture = SubResource("PlaceholderTexture2D_h3mns")
 expand_mode = 1
 stretch_mode = 5
 


### PR DESCRIPTION
Hey,

I found a small problem / warning while including the `godot-4` branch into my project using Godot 4.2.1:
> scene/resources/resource_format_text.cpp:448 - res://addons/resources_spreadsheet_view/typed_editors/dock_texture.tscn:4
> ext_resource, invalid UID: uid://c08qavfwqr3k7 - using text path instead: res://icon.png

I suspect this warning will get shown for every project using the plugin.

<br>

I've replaced the placeholder texture for the `dock_texture` scene with well, a placeholder texture :)

Otherwise a really awesome plugin, thank you for all the work put into it 🎉 