### PR TITLE
Godot 4 Fixes: Arrows Keys Cell Selection + Deprecated <convert()> replacement

### DIFF
--- a/addons/resources_spreadsheet_view/editor_view.gd
+++ b/addons/resources_spreadsheet_view/editor_view.gd
@@ -460,7 +460,7 @@ func try_convert(value, type):
 		return value[0] == "o"
 
 	# If it can't convert, throws exception and returns null.
-	return convert(value, type)
+	return type_convert(value, type)
 
 
 func _on_path_text_submitted(new_text : String = ""):

--- a/addons/resources_spreadsheet_view/main_screen/input_handler.gd
+++ b/addons/resources_spreadsheet_view/main_screen/input_handler.gd
@@ -135,16 +135,15 @@ func _key_specific_action(event : InputEvent):
 
 func _move_selection_on_grid(move_h : int, move_v : int):
 	var selected_cells := selection.edited_cells.duplicate()
-	var child_count := editor_view.node_table_root.get_child_count()
-	var new_child_index := 0
+	var num_columns := editor_view.columns.size()
+	var num_rows := editor_view.rows.size()
+	var new_child_index := Vector2i(0, 0)
 	for i in selected_cells.size():
-		new_child_index = (
-			selected_cells[i].get_index()
-			+ move_h
-			+ move_v * editor_view.columns.size()
+		new_child_index = Vector2i(
+			clamp(selected_cells[i].x + move_h, 0, num_columns - 1),
+			clamp(selected_cells[i].y + move_v, 0, num_rows - 1),
 		)
-		if child_count < new_child_index: continue
-		selected_cells[i] = editor_view.node_table_root.get_child(new_child_index)
+		selected_cells[i] = new_child_index
 
 	editor_view.grab_focus()
 	selection.deselect_all_cells()

--- a/addons/resources_spreadsheet_view/main_screen/selection_manager.gd
+++ b/addons/resources_spreadsheet_view/main_screen/selection_manager.gd
@@ -113,7 +113,10 @@ func select_cell(cell : Vector2i):
 func select_cells(cells : Array):
 	var last_selectible : Vector2i = Vector2i(-1, -1)
 	for x in cells:
-		if x.mouse_filter != MOUSE_FILTER_IGNORE and can_select_cell(x):
+		var node: Node = get_cell_node_from_position(x)
+		if node == null:
+			continue
+		if node.mouse_filter != MOUSE_FILTER_IGNORE and can_select_cell(x):
 			_add_cell_to_selection(x)
 			last_selectible = x
 


### PR DESCRIPTION
This is a simple fix that updates the Arrow Keys selection to use the Vector2i-based environment, instead of Node (as it used to, as far as I understand).

Feel free to modify the code as you wish.