### PR TITLE
Fix for overwriting existing resources

### DIFF
--- a/addons/resources_spreadsheet_view/import_export/spreadsheet_import.gd
+++ b/addons/resources_spreadsheet_view/import_export/spreadsheet_import.gd
@@ -242,7 +242,7 @@ func strings_to_resource(strings : Array, destination_path : String) -> Resource
 		destination_path = edited_path.get_base_dir().path_join("import/")
 		DirAccess.make_dir_recursive_absolute(destination_path)
 
-	var new_path : String = strings[prop_names.find(prop_used_as_filename)].trim_suffix(".tres") + ".tres"
+	var new_path : String = strings[prop_names.find(prop_used_as_filename)].trim_suffix(".tres")
 	if !FileAccess.file_exists(new_path):
 		new_path = destination_path.path_join(new_path) + ".tres"
 


### PR DESCRIPTION
When attempting to reimport a CSV, expected behavior seems to be that existing resources should be overwritten. But in all cases I've tried it an error was thrown.

This seems to be due to existing resources getting a double '.tres' extension causing: 

![image](https://github.com/user-attachments/assets/36389d76-fc71-4c6a-b48b-6b2ac884af12)

This fix addresses that.