### PR TITLE
Minor Import window UI/UX enhancement

### DIFF
--- a/addons/resources_spreadsheet_view/import_export/import_export_dialog.gd
+++ b/addons/resources_spreadsheet_view/import_export/import_export_dialog.gd
@@ -11,7 +11,7 @@ extends Control
 @onready var script_path_field := $"Import/Margins/Scroll/Box/Grid/HBoxContainer/LineEdit"
 @onready var prop_list := $"Import/Margins/Scroll/Box"
 @onready var format_settings := $"Import/Margins/Scroll/Box/StyleSettingsI"
-@onready var file_dialog := $"../../FileDialogText"
+#@onready var file_dialog := $"../../FileDialogText"
 
 var format_extension := ".csv"
 var entries := []

--- a/addons/resources_spreadsheet_view/import_export/import_export_dialog.tscn
+++ b/addons/resources_spreadsheet_view/import_export/import_export_dialog.tscn
@@ -80,6 +80,7 @@ size = Vector2i(800, 500)
 ok_button_text = "Open"
 mode_overrides_title = false
 file_mode = 0
+filters = PackedStringArray("*.gd", "*.cs")
 
 [node name="Control" type="Control" parent="Import/Margins/Scroll/Box/Grid"]
 layout_mode = 2


### PR DESCRIPTION
I KEEP picking the wrong file when looking for 'existing resource scripts' in the import dialog window. This change filters out non .gd or .cs files so you don't accidnetly pick a similarly named CSV or CSV translation file.

It also comments out a no longer existing file path to cut down on error messages.

I also feel from a UX stand point having the destination folder for imports be visible and selectable in this window makes more sense then having it in the dock:
![image](https://github.com/user-attachments/assets/8358b1ff-080f-42b5-8030-5d285435650c)
But I figure that would be a discussion and another PR.