### PR TITLE
Word-wrap for long strings

### DIFF
--- a/addons/resources_spreadsheet_view/typed_cells/cell_editor_string.gd
+++ b/addons/resources_spreadsheet_view/typed_cells/cell_editor_string.gd
@@ -7,11 +7,15 @@ func create_cell(caller : Control) -> Control:
 	return cell_scene
 
 func _resize_text(cell: Label):
-	if cell.text.length() <= 65:
-		cell.autowrap_mode = TextServer.AUTOWRAP_OFF
-	else:
+	var string_size = cell.get_theme_font("font").get_string_size(cell.text, HORIZONTAL_ALIGNMENT_LEFT, -1, cell.get_theme_font_size("normal_font_size"))
+	var string_width = string_size.x
+	var max_column_width = DisplayServer.window_get_size().x / 3
+	if string_width >= max_column_width:
 		cell.autowrap_mode = TextServer.AUTOWRAP_WORD
-		cell.custom_minimum_size.x = 350
+		cell.custom_minimum_size.x = 500
+	else:
+		cell.autowrap_mode = TextServer.AUTOWRAP_OFF
+		cell.custom_minimum_size.x = 24
 
 func to_text(value) -> String:
 	return str(value)

--- a/addons/resources_spreadsheet_view/typed_cells/cell_editor_string.gd
+++ b/addons/resources_spreadsheet_view/typed_cells/cell_editor_string.gd
@@ -9,10 +9,10 @@ func create_cell(caller : Control) -> Control:
 func _resize_text(cell: Label):
 	var string_size = cell.get_theme_font("font").get_string_size(cell.text, HORIZONTAL_ALIGNMENT_LEFT, -1, cell.get_theme_font_size("normal_font_size"))
 	var string_width = string_size.x
-	var max_column_width = DisplayServer.window_get_size().x / 3
+	var max_column_width = DisplayServer.window_get_size().x / 4
 	if string_width >= max_column_width:
 		cell.autowrap_mode = TextServer.AUTOWRAP_WORD
-		cell.custom_minimum_size.x = 500
+		cell.custom_minimum_size.x = max_column_width
 	else:
 		cell.autowrap_mode = TextServer.AUTOWRAP_OFF
 		cell.custom_minimum_size.x = 24

--- a/addons/resources_spreadsheet_view/typed_cells/cell_editor_string.gd
+++ b/addons/resources_spreadsheet_view/typed_cells/cell_editor_string.gd
@@ -1,6 +1,18 @@
 extends ResourceTablesCellEditor
 
 
+func create_cell(caller : Control) -> Control:
+	var cell_scene: Label = load(CELL_SCENE_DIR + "basic.tscn").instantiate()
+	cell_scene.resized.connect(_resize_text.bind(cell_scene))
+	return cell_scene
+
+func _resize_text(cell: Label):
+	if cell.text.length() <= 65:
+		cell.autowrap_mode = TextServer.AUTOWRAP_OFF
+	else:
+		cell.autowrap_mode = TextServer.AUTOWRAP_WORD
+		cell.custom_minimum_size.x = 350
+
 func to_text(value) -> String:
 	return str(value)
 


### PR DESCRIPTION
This is the first time I've ever made a pull request to someone I didn't already know, so...please excuse me if I'm doing it wrong or rude or something.

I've found working with strings longer than ~50 characters gets awkward when they're all on one line in the table, so I wrote a little word-wrap function for it, and thought maybe it'd be helpful for others?

It connects each string cell's "resized" signal to a function that checks the text width and window width and activates or deactivates word-wrap depending on their ratio (currently hard-coded to 1/4).